### PR TITLE
properly match AnyType NewUnionCase

### DIFF
--- a/Qit.Tests/Library1.fs
+++ b/Qit.Tests/Library1.fs
@@ -451,6 +451,14 @@ module Basic =
         | BindQuote <@ (Quote.withType "x" : ConcatBuilder<AnyType>).Delay(Quote.withType "body") : AnyType []@> (Marker "x" x & Marker "body" b) ->
             ()
         | _ -> Assert.False(true)
+    
+    [<Fact>]
+    let ``BindQuote any instance obj 4``() = 
+        let isMatch = 
+            match <@ [] : int list @> with 
+            | BindQuote <@ [] : AnyType list @> _ -> true
+            | _ -> false
+        Assert.True(isMatch)
 
     [<Fact>]
     let ``BindQuote multiple matches 1``() = 

--- a/Qit/Patterns.fs
+++ b/Qit/Patterns.fs
@@ -6,6 +6,9 @@ open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
 open System.Collections.Generic
 
+/// <summary>
+/// Provides active patterns for matching and extracting information from F# quotations and reflection elements (like MethodInfo, PropertyInfo, and FieldInfo).
+/// </summary>
 [<AutoOpen>]
 module Patterns = 
     open Quote

--- a/Qit/ProvidedTypes.fsi
+++ b/Qit/ProvidedTypes.fsi
@@ -85,6 +85,8 @@ type ProvidedConstructor =
     /// This method is for internal use only in the type provider SDK
     member internal GetInvokeCode: Expr list -> Expr
 
+
+/// Represents an erased provided method.
 [<Class>]
 type ProvidedMethod =
     inherit MethodInfo
@@ -394,8 +396,8 @@ type ProvidedAssembly =
 
 #endif
 
-[<Class>]
 /// Represents the context for which code is to be generated. Normally you should not need to use this directly.
+[<Class>]
 type ProvidedTypesContext = 
     
     new : config: TypeProviderConfig * assemblyReplacementMap: (string*string) list * sourceAssemblies: Assembly list -> ProvidedTypesContext
@@ -574,7 +576,11 @@ module internal AssemblyReader =
         val GetWeakReaderCache : unit -> System.Collections.Concurrent.ConcurrentDictionary<(string * string), DateTime * WeakReference<ILModuleReader>>
         val GetStrongReaderCache : unit -> System.Collections.Concurrent.ConcurrentDictionary<(string * string), DateTime * int * ILModuleReader>
 
+/// Assembly compiler for generative type providers.
 [<Class>]
 type AssemblyCompiler = 
     new : targetAssembly: ProvidedAssembly * context: ProvidedTypesContext -> AssemblyCompiler
+    /// <summary>Compiles the ProvidedAssembly under the ProvidedTypesContext</summary>
+    /// <param name="isHostedExecution">True if calling from F# Interactive. Will load the resulting assembly and set the Assembly of child ProvidedTypes.</param>
+    /// <returns>The compiled assembly as a byte array</returns>
     member Compile : isHostedExecution : bool -> byte []

--- a/Qit/Qit.fsproj
+++ b/Qit/Qit.fsproj
@@ -5,7 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
     <PackageId>Qit</PackageId>
-    <Version>0.2.0</Version>
+    <Version>0.3.0</Version>
     <Authors>Kevin Malenfant</Authors>
     <Description>Quotation toolkit</Description>
     <PackageProjectUrl>https://github.com/kevmal/Qit</PackageProjectUrl>


### PR DESCRIPTION
Test case was added. 

```fsharp
        let isMatch = 
            match <@ [] : int list @> with 
            | BindQuote <@ [] : AnyType list @> _ -> true
            | _ -> false
````

Was failing since the `UnionCaseInfo` was not properly being checked.

Added some docs, and also removed `IHole` for the time being.